### PR TITLE
Test auto release to patch version 0.0.24

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@latitudegames/thoth-core",
   "version": "0.0.24",
-  "description": "core shareable logic for thoth",
+  "description": "core shared code for thoth",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.25--canary.77.6c349655cfd6235b77b5170c503aa1961893fb5c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.25--canary.77.6c349655cfd6235b77b5170c503aa1961893fb5c.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.25--canary.77.6c349655cfd6235b77b5170c503aa1961893fb5c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
