### PR TITLE
Add prelease flag to shipit command

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "lint": "eslint . --ignore-path ../.eslintignore --ext ts --ext tsx --ext js --ext jsx",
-    "preship": "yarn build && copyfiles package.json .npmrc dist && cd plugins/areaPlugin/ && copyfiles style.css ../../dist/plugins/areaPlugin/ && cd ../../dist && auto shipit --base-branch main",
+    "preship": "yarn build && copyfiles package.json .npmrc dist && cd plugins/areaPlugin/ && copyfiles style.css ../../dist/plugins/areaPlugin/ && cd ../../dist && auto shipit --prerelease --base-branch main",
     "postpublish": "yarn clean"
   },
   "dependencies": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.25--canary.80.5823bf8d824ea53b2eafecfe1763376d52602b75.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.25--canary.80.5823bf8d824ea53b2eafecfe1763376d52602b75.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.25--canary.80.5823bf8d824ea53b2eafecfe1763376d52602b75.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
