### PR TITLE
Adjust env var template for latest tag and skip patch 28 due to tag c…

### DIFF
--- a/.github/workflows/thoth-core-release.yml
+++ b/.github/workflows/thoth-core-release.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install
       - name: Prepare and Release
         working-directory: core
-        run: yarn preship && yarn auto release --from="{{ env.LATEST_TAG }}" --prerelease --base-branch main
+        run: yarn preship && yarn auto release --from="${{ env.LATEST_TAG }}" --prerelease --base-branch main
       - name: Increment package for future prelease, commit and push
         working-directory: core
         run: |

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitudegames/thoth-core",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "core shared code for thoth",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
…onflicts
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.30--canary.91.aa89483a8f77bc8ae31b54ad173e17ece2140321.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.30--canary.91.aa89483a8f77bc8ae31b54ad173e17ece2140321.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.30--canary.91.aa89483a8f77bc8ae31b54ad173e17ece2140321.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
