### PR TITLE
Remove manual tag step due to conflict with auto defaults, skip pathc…

### DIFF
--- a/.github/workflows/thoth-core-release.yml
+++ b/.github/workflows/thoth-core-release.yml
@@ -24,10 +24,6 @@ jobs:
       - name: set git tag name to enviroment
         working-directory: core
         run: echo "LATEST_TAG=v$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
-      - name: add and push git tag
-        run: |
-          git tag ${{ env.LATEST_TAG }}
-          git push --tags
       - name: Install Dependencies
         run: yarn install
       - name: Prepare and Release

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitudegames/thoth-core",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "core shared code for thoth",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
…hes 29 and 30 due to tag conflicts
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.32--canary.92.1c3c917d9d1ac98a45331ffeeff8df80a635edc0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.32--canary.92.1c3c917d9d1ac98a45331ffeeff8df80a635edc0.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.32--canary.92.1c3c917d9d1ac98a45331ffeeff8df80a635edc0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
