### PR TITLE
Set package version to 32 inline with current release expectations, r…

### DIFF
--- a/.github/workflows/thoth-core-release.yml
+++ b/.github/workflows/thoth-core-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: set git tag name to enviroment
         working-directory: core
         run: echo "LATEST_TAG=v$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
+      - name: add git tag and push
+        run: |
+          git tag ${{ env.LATEST_TAG }}
+          git push --tags
       - name: Install Dependencies
         run: yarn install
       - name: Prepare and Release

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitudegames/thoth-core",
-  "version": "0.0.34",
+  "version": "0.0.32",
   "description": "core shared code for thoth",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
…e-enable pushing newly created tag
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.33--canary.97.ebc6380edde7673cd3f712b36cdc75b06ce3dd85.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.33--canary.97.ebc6380edde7673cd3f712b36cdc75b06ce3dd85.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.33--canary.97.ebc6380edde7673cd3f712b36cdc75b06ce3dd85.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
