### PR TITLE
Remove postpublish step from core and add npm publish to release cond…

### DIFF
--- a/.github/workflows/thoth-core-release.yml
+++ b/.github/workflows/thoth-core-release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Prepare and Release
         working-directory: core
         run: yarn preship && yarn auto release --prerelease
+      - name: Publish to GitHub Packages
+        working-directory: core/dist
+        run: npm publish
       - name: Increment package for future prelease, commit and push
         working-directory: core
         run: |

--- a/core/package.json
+++ b/core/package.json
@@ -8,8 +8,7 @@
     "lint": "eslint . --ignore-path ../.eslintignore --ext ts --ext tsx --ext js --ext jsx",
     "preship": "yarn build && copyfiles package.json .npmrc dist && cd plugins/areaPlugin/ && copyfiles style.css ../../dist/plugins/areaPlugin/ && cd ../../dist",
     "ship": "auto release --prerelease --base-branch main",
-    "release": "yarn preship && yarn ship",
-    "postpublish": "yarn clean"
+    "release": "yarn preship && yarn ship"
   },
   "dependencies": {
     "auto": "^10.32.0",


### PR DESCRIPTION
…itions for thoth-core
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.34--canary.98.13d4696f3a0640f8554de18b24cb292d09e63c96.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.34--canary.98.13d4696f3a0640f8554de18b24cb292d09e63c96.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.34--canary.98.13d4696f3a0640f8554de18b24cb292d09e63c96.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
