### PR TITLE
Target existing published version of core in client, bump core patch …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "install:canary": "yarn add @latitudegames/thoth-core@canary"
   },
   "dependencies": {
-    "@latitudegames/thoth-core": "0.0.34",
+    "@latitudegames/thoth-core": "0.0.33",
     "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
     "@monaco-editor/react": "^4.2.1",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitudegames/thoth-core",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "core shared code for thoth",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
…to .36 to avoid collisions with git tags