### PR TITLE
Add checkout step to reset yarn.lock that is crashing canary publishi…

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -61,5 +61,5 @@ jobs:
         if: steps.core_diff.outcome != 'success' && (steps.no_thoth_core_label.outcome == 'success' || contains(github.event.pull_request.labels.*.name, 'thoth-core'))
 
       - name: Publish next canary release of @latitudegames/thoth-core
-        run: yarn publish:canary
+        run: git checkout yarn.lock && yarn publish:canary
         if: steps.core_diff.outcome != 'success' && (steps.no_thoth_core_label.outcome == 'success' || contains(github.event.pull_request.labels.*.name, 'thoth-core'))


### PR DESCRIPTION
…ng on the PR ci
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.42--canary.107.283d9ea1a3910ca15420a1d9449dd0f0c5ac03ed.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.42--canary.107.283d9ea1a3910ca15420a1d9449dd0f0c5ac03ed.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.42--canary.107.283d9ea1a3910ca15420a1d9449dd0f0c5ac03ed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
