### PR TITLE
Add regengerator runtime to dependencies

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -24,6 +24,7 @@
     "jsdom": "^17.0.0",
     "path": "^0.12.7",
     "react": "^17.0.2",
+    "regenerator-runtime": "^0.13.9",
     "rete": "https://github.com/latitudegames/rete.git#master",
     "rete-area-plugin": "^0.2.1",
     "rete-connection-plugin": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12311,14 +12311,6 @@ rete-react-render-plugin@^0.2.1:
   resolved "https://registry.yarnpkg.com/rete-react-render-plugin/-/rete-react-render-plugin-0.2.1.tgz#71a6d73f18f850b85262563f678b40080a7b0e32"
   integrity sha512-2ZMXUP0v+EiejHVMqdrOmUwyDBHC2UDOJ/pFkElaZL1Kn/E40JZA5yzdBXi6ajYZI2DCzoW5ZBcA2Ihjtur8MQ==
 
-"rete@git+https://github.com/latitudegames/rete.git#master":
-  version "1.4.5"
-  uid "24565a81a2bbcdd4cd73b0a725977550cc8ff988"
-  resolved "git+https://github.com/latitudegames/rete.git#24565a81a2bbcdd4cd73b0a725977550cc8ff988"
-  dependencies:
-    lodash "^4.17.21"
-    watch "^1.0.2"
-
 "rete@https://github.com/latitudegames/rete.git#master":
   version "1.4.5"
   resolved "https://github.com/latitudegames/rete.git#24565a81a2bbcdd4cd73b0a725977550cc8ff988"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.51--canary.117.a1663bc32193ab795f7001ac28c866c276b64e5e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.51--canary.117.a1663bc32193ab795f7001ac28c866c276b64e5e.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.51--canary.117.a1663bc32193ab795f7001ac28c866c276b64e5e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
