### PR TITLE
Add frequencyPenalty data control to generator component

### DIFF
--- a/core/src/components/Generator.ts
+++ b/core/src/components/Generator.ts
@@ -78,6 +78,11 @@ export class Generator extends ThothComponent {
       icon: 'moon',
     })
 
+    const frequencyPenalty = new InputControl({
+      dataKey: 'frequencyPenalty',
+      name: 'Frequency Penalty',
+    })
+
     node.inspector
       .add(nameControl)
       .add(inputGenerator)
@@ -85,6 +90,7 @@ export class Generator extends ThothComponent {
       .add(stopControl)
       .add(temperatureControl)
       .add(maxTokenControl)
+      .add(frequencyPenalty)
 
     return node
   }
@@ -105,6 +111,7 @@ export class Generator extends ThothComponent {
     const stopSequence = node.data.stop as string
     const temp = node.data.temp as string
     const maxTokensData = node?.data?.maxTokens as string
+    const frequencyPenaltyData = node?.data?.frequencyPenalty as string
     const template = Handlebars.compile(fewshot)
     const prompt = template(inputs)
 
@@ -114,12 +121,16 @@ export class Generator extends ThothComponent {
 
     const temperature = node?.data?.temp ? parseFloat(temp) : 0.7
     const maxTokens = maxTokensData ? parseInt(maxTokensData) : 50
+    const frequencyPenalty = frequencyPenaltyData
+      ? parseInt(frequencyPenaltyData)
+      : 0
 
     const body = {
       prompt,
       stop,
       maxTokens,
       temperature,
+      frequencyPenalty,
     }
     const raw = (await completion(body)) as string
     const result = raw?.trim()


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.58--canary.126.25de52ad963ab64d3ba4af42aa2f6fa7fd2a0cbf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @latitudegames/thoth-core@0.0.58--canary.126.25de52ad963ab64d3ba4af42aa2f6fa7fd2a0cbf.0
  # or 
  yarn add @latitudegames/thoth-core@0.0.58--canary.126.25de52ad963ab64d3ba4af42aa2f6fa7fd2a0cbf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
